### PR TITLE
fix building in DispVM

### DIFF
--- a/whonix-gateway/02_install_groups_pre.sh
+++ b/whonix-gateway/02_install_groups_pre.sh
@@ -147,7 +147,7 @@ if [ -f "${INSTALLDIR}/${TMPDIR}/.whonix_prepared_groups" ] && ! [ -f "${INSTALL
     #### '----------------------------------------------------------------------
     pushd "${WHONIX_DIR}"
     {
-        su $(logname) -c "git submodule update --init --recursive";
+        su $(logname || echo $SUDO_USER) -c "git submodule update --init --recursive";
     }
     popd
 


### PR DESCRIPTION
When the build is started in DispVM, logname can't get the actual user
name (most likely because there is no terminal connected). This results
in getting Whonix sources as root and later user cannot access those
sources.